### PR TITLE
Added MacOS support and fixed package whitelist check

### DIFF
--- a/OneClickInstall.sh
+++ b/OneClickInstall.sh
@@ -7,6 +7,8 @@ if [ $# -lt 2 ]
         exit 127
 fi
 
+uname=`uname`
+
 echo "Disconnecting other adb devices\n"
 adb disconnect
 sleep 1
@@ -59,12 +61,19 @@ fi
 
 #If we're at this point of the script, we have root & ADB connection established
 echo "Okay, getting signature of $2"
-
-sig=`java -jar bin/GetAndroidSig.jar "$2" | grep "To char" | sed -r 's/^.{9}//'`
+if [ "$uname" = "Darwin" ]; then
+    sig=`java -jar bin/GetAndroidSig.jar "$2" | grep "To char" | sed -E 's/^.{9}//'`
+else
+    sig=`java -jar bin/GetAndroidSig.jar "$2" | grep "To char" | sed -r 's/^.{9}//'`
+fi
 echo "Signature: $sig"
 
 echo "Getting package information"
-package=`aapt dump permissions "$2" | head -1 | sed -r 's/^.{9}//'`
+if [ "$uname" = "Darwin" ]; then
+    package=`aapt dump permissions "$2" | head -1 | sed -E 's/^.{9}//'`
+else
+    package=`aapt dump permissions "$2" | head -1 | sed -r 's/^.{9}//'`
+fi
 echo "Package name: $package"
 echo "Retrieving current whitelist..."
 `adb shell "su -c 'cp /data/system/whitelist.xml /data/local/tmp/'"`

--- a/OneClickInstall.sh
+++ b/OneClickInstall.sh
@@ -141,7 +141,7 @@ echo "Original whitelist.xml size DOES NOT seem okay (bad!)"
 fi
 
 packagecheck=`grep $package whitelist-new.xml`
-if [ ! -z "$package" ]; then
+if [ ! -z "$packagecheck" ]; then
 echo "Package name is present in new whitelist"
 else
 echo "Package name is NOT present in new whitelist (bad!)"


### PR DESCRIPTION
Credit for finding these goes to @codeage.

You should also close these issues:
[$packagecheck](https://github.com/jersacct/2016PilotOneClick/issues/2)
[sed issues on macOS](https://github.com/jersacct/2016PilotOneClick/issues/5)